### PR TITLE
use WSDOT default inputs

### DIFF
--- a/Bearing/BearingDoc.cpp
+++ b/Bearing/BearingDoc.cpp
@@ -132,12 +132,12 @@ BOOL CBearingDoc::Init()
 
    m_criteria.SetSpecification(WBFL::LRFD::BDSManager::GetLatestEdition());
 
-   m_criteria.AnalysisMethod = BearingAnalysisMethod::MethodA;
+   m_criteria.AnalysisMethod = BearingAnalysisMethod::MethodB;
 
    m_bearing.SetLength(WBFL::Units::ConvertToSysUnits(11.0, WBFL::Units::Measure::Inch));
    m_bearing.SetWidth(WBFL::Units::ConvertToSysUnits(27.0, WBFL::Units::Measure::Inch));
-   m_bearing.SetShearModulusMinimum(WBFL::Units::ConvertToSysUnits(165, WBFL::Units::Measure::PSI));
-   m_bearing.SetShearModulusMaximum(WBFL::Units::ConvertToSysUnits(165, WBFL::Units::Measure::PSI));
+   m_bearing.SetShearModulusMinimum(WBFL::Units::ConvertToSysUnits(140, WBFL::Units::Measure::PSI));
+   m_bearing.SetShearModulusMaximum(WBFL::Units::ConvertToSysUnits(190, WBFL::Units::Measure::PSI));
    m_bearing.SetIntermediateLayerThickness(WBFL::Units::ConvertToSysUnits(0.5, WBFL::Units::Measure::Inch));
    m_bearing.SetCoverThickness(WBFL::Units::ConvertToSysUnits(0.25, WBFL::Units::Measure::Inch));
    m_bearing.SetSteelShimThickness(WBFL::Units::ConvertToSysUnits(0.0747, WBFL::Units::Measure::Inch));


### PR DESCRIPTION
uses Method B, sets Gmin = 140 psi and Gmax = 190 psi in the doc. Obviously the default inputs aren't defined by any specific project criteria, just AASHTO LRFD. However, most of the users seem to be in WA state, so I think this is a better starting point.
I checked to make sure it doesn't affect older files